### PR TITLE
Adapt plugin for new config, improve promise resolving

### DIFF
--- a/src/utils/prepareModules.js
+++ b/src/utils/prepareModules.js
@@ -91,28 +91,30 @@ async function setAliases(configurations, { allModules }) {
  * @returns {Promise<string>}
  */
 async function setPlugins(configurations, { allModules }) {
-    return new Promise((resolve) => {
-        configurations.forEach((configuration) => {
-            if (configuration.plugins) {
-                const { name, plugins } = configuration;
+    await Promise.all(
+        configurations
+            .filter((configuration) => configuration.plugins)
+            .map(({ name, plugins }) => {
                 const moduleName = name.replace(/[^a-zA-Z]/g, '');
 
-                plugins.forEach(async ({ ssr, src }) => {
+                return plugins.map(({ ssr, src }) => {
                     const pluginPath = join(
                         allModules.find((m) => m.name === name).path,
                         src,
                     ).replace(/\/$/g, '');
 
-                    await this.addPlugin({
+                    return this.addPlugin({
                         src: `${pluginPath}.js`,
                         fileName: join('modules', moduleName, `${src}.js`),
-                        ssr,
+                        options: {
+                            mode: ssr ? 'server' : 'client',
+                        },
                     });
                 });
-            }
-        });
-        resolve('All plugins set');
-    });
+            }),
+    );
+
+    return 'All plugins set';
 }
 
 /**


### PR DESCRIPTION
According to the docs [plugins](https://nuxtjs.org/docs/internals-glossary/internals-module-container/#addplugin-template) there is not anymore `ssr` option and also from the code:

```
// Add to nuxt plugins
    this.options.plugins.unshift({
      src: path__default['default'].join(this.options.buildDir, dst),
      // TODO: remove deprecated option in Nuxt 3
      ssr: template.ssr,
      mode: template.mode
    });
```

we can see that the `ssr` option is deprecated.

- Added support for `mode` instead of `ssr` for plugins setting.
- Promises doesn't rly work for forEach looping. Mapped plugins registration into `Promise.all`.