### PR TITLE
feature: replace routing helper

### DIFF
--- a/docs/content/en/module-config.md
+++ b/docs/content/en/module-config.md
@@ -311,15 +311,55 @@ Sometimes you need to replace certain elements or add some to already existing s
 In order not to modify existing modules, **VueMS library** provides a solution to easily extend already existing mechanisms.
 Thanks to it we have a lot of possibilities to extend modules from other modules.
 
-In order to add any extensions you need to create an `extend.js` file
+In order to add any extensions you need to create an `extends.js` file
 and use specific properties in it depending on what you want to achieve.
 
 
 <alert type="info">
-  You don't need to create an <code>extend.js</code>  file if you don't want to extend anything
+  You don't need to create an <code>extends.js</code>  file if you don't want to extend anything
 </alert>
 
 #### Properties:
+---
+
+* `replaceRoutes`
+    - Type: `Array`
+
+This functionality allows you to replace a routing page by his name.
+The mechanism is based on routing and extends existing routing.
+
+**`replaceRoutes`:**<br>
+    - `name` - existing router name what we want replace,<br>
+    - `routes` - new routing to replace,<br>
+
+```javascript [@Products/config/extends.js]
+export default {
+    replaceRoutes: [
+        {
+            name: 'products',
+            routes: {
+                name: 'products-new',
+                path: '/new-products',
+                component: Tabs.Product,
+                meta: {
+                    title: 'New Products',
+                    visible: false,
+                    breadcrumbs: [
+                        {
+                            title: 'New Products',
+                            icon: Icons.Product,
+                        },
+                    ],
+                    privileges: [],
+                },
+            },
+        },
+    ],
+};
+```
+<alert type="info">
+  The extended routing <b>must exist</b>. The mechanism substitutes all routing with the given name. <br>First the routing is replaced and then extended (<code>extendRoutesChildren</code>), so if a routing is added to the given name, it will be added correctly.
+</alert>
 
 ---
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuems",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "nuxt",
@@ -10,8 +10,8 @@
     "deploy": "push-dir --dir=dist --branch=docs --remote=upstream --cleanup"
   },
   "dependencies": {
-    "@nuxt/content-theme-docs": "^0.8.2",
-    "nuxt": "^2.15.7"
+    "@nuxt/content-theme-docs": "^0.11.1",
+    "nuxt": "^2.15.8"
   },
   "devDependencies": {
     "push-dir": "^0.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ergonode/vuems",
-  "version": "0.15.1",
+  "version": "1.0.0",
   "description": "A simple mechanism to transform a monolithic Vue application into an application based on Micro Services architecture.",
   "author": "Bletek Piotr <p.bletek@gmail.com>",
   "license": "OSL",
@@ -41,21 +41,21 @@
     "consola": "^2.15.3",
     "deepmerge": "^4.2.2",
     "fs-extra": "^10.0.0",
-    "recursive-readdir-async": "^1.1.8"
+    "recursive-readdir-async": "^1.2.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "babel-eslint": "^10.1.0",
     "babel-plugin-dynamic-import-node": "^2.3.3",
-    "eslint": "^7.30.0",
-    "eslint-config-airbnb": "^18.2.1",
+    "eslint": "^8.4.0",
+    "eslint-config-airbnb": "^19.0.2",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-notice": "^0.9.10",
-    "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-react": "^7.24.0",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.3.2"
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react": "^7.27.1",
+    "eslint-plugin-react-hooks": "^4.3.0",
+    "prettier": "^2.5.1"
   }
 }

--- a/src/templates/plugin.ejs
+++ b/src/templates/plugin.ejs
@@ -10,8 +10,10 @@ import extendsModules from '~/.nuxt/extends.modules';
 
 export default ({ app }, inject) => {
     const extendMethods = {};
-    const extendComponents = Object.values(extendsModules)
-        .reduce((acc, current) => deepmerge(acc, current.extendComponents || {}), {});
+    const extendComponents = Object.values(extendsModules).reduce(
+        (acc, current) => deepmerge(acc, current.extendComponents || {}),
+        {},
+    );
 
     Object.values(extendsModules).forEach((extendContent) => {
         if (extendContent.extendMethods) {
@@ -21,16 +23,20 @@ export default ({ app }, inject) => {
                         extendContent.extendMethods[extendName],
                     ];
                 } else {
-                    extendMethods[extendName].push(extendContent.extendMethods[extendName]);
+                    extendMethods[extendName].push(
+                        extendContent.extendMethods[extendName],
+                    );
                 }
             });
         }
     });
 
-    inject('getExtendSlot', key => extendComponents[key] || {});
+    inject('getExtendSlot', (key) => extendComponents[key] || {});
     inject('getExtendMethod', async (key, payload) => {
         if (extendMethods[key]) {
-            const methods = await Promise.all(extendMethods[key].map(method => method(payload)));
+            const methods = await Promise.all(
+                extendMethods[key].map((method) => method(payload)),
+            );
 
             return methods;
         }

--- a/src/templates/pluginVuex.ejs
+++ b/src/templates/pluginVuex.ejs
@@ -3,6 +3,7 @@
  * See LICENSE for license details.
  */
 /* eslint-disable no-await-in-loop */
+/* eslint-disable no-param-reassign */
 
 import deepmerge from 'deepmerge';
 import extendsModules from '~/.nuxt/extends.modules';
@@ -24,25 +25,30 @@ export default async ({ app }) => {
 
     await asyncForEach(Object.values(extendsModules), async (extendContent) => {
         if (extendContent.extendStore) {
-            await asyncForEach(Object.keys(extendContent.extendStore), async (extendName) => {
-                const tmpStore = {};
-                const storeContent = await extendContent.extendStore[extendName]();
+            await asyncForEach(
+                Object.keys(extendContent.extendStore),
+                async (extendName) => {
+                    const tmpStore = {};
+                    const storeContent = await extendContent.extendStore[
+                        extendName
+                    ]();
 
-                Object.keys(storeKeys).forEach((key) => {
-                    if (storeContent[key]) {
-                        if (key === 'state') {
-                            tmpStore[key] = storeContent[key]();
-                        } else {
-                            tmpStore[key] = storeContent[key];
+                    Object.keys(storeKeys).forEach((key) => {
+                        if (storeContent[key]) {
+                            if (key === 'state') {
+                                tmpStore[key] = storeContent[key]();
+                            } else {
+                                tmpStore[key] = storeContent[key];
+                            }
                         }
-                    }
-                });
+                    });
 
-                extendedStore[extendName] = deepmerge(
-                    extendedStore[extendName] || {},
-                    tmpStore,
-                );
-            });
+                    extendedStore[extendName] = deepmerge(
+                        extendedStore[extendName] || {},
+                        tmpStore,
+                    );
+                },
+            );
         }
     });
 
@@ -50,8 +56,10 @@ export default async ({ app }) => {
         actions: {
             resetState({ dispatch }) {
                 Object.keys(storeModules).forEach((storeName) => {
-                    if (app.store._actions[`${storeName}/__clearStorage`]
-                            && app.store._actions[`${storeName}/__clearStorage`].length) {
+                    if (
+                        app.store._actions[`${storeName}/__clearStorage`] &&
+                        app.store._actions[`${storeName}/__clearStorage`].length
+                    ) {
                         dispatch(`${storeName}/__clearStorage`);
                     }
                 });
@@ -60,7 +68,8 @@ export default async ({ app }) => {
     });
 
     Object.keys(storeModules).forEach((storeName) => {
-        const moduleIsRegistered = app.store._modules.root._children[storeName] !== undefined;
+        const moduleIsRegistered =
+            app.store._modules.root._children[storeName] !== undefined;
         const stateExists = app.store.state[storeName];
         let states = storeModules[storeName].state();
 
@@ -92,31 +101,35 @@ export default async ({ app }) => {
 
         // DEFAULT VUEX METHODS
         // MUTATIONS
-        storeModules[storeName].mutations.__CLEAR_STORAGE = function __CLEAR_STORAGE(state) {
-            Object.keys(states).forEach((key) => {
-                state[key] = states[key];
-            });
-        };
-        storeModules[storeName].mutations.__SET_STATE = function __SET_STATE(state, {
-            key, value,
-        }) {
+        storeModules[storeName].mutations.__CLEAR_STORAGE =
+            function __CLEAR_STORAGE(state) {
+                Object.keys(states).forEach((key) => {
+                    state[key] = states[key];
+                });
+            };
+        storeModules[storeName].mutations.__SET_STATE = function __SET_STATE(
+            state,
+            { key, value },
+        ) {
             state[key] = value;
         };
 
         // ACTIONS
-        storeModules[storeName].actions.__clearStorage = function __clearStorage({ commit }) {
-            commit('__CLEAR_STORAGE');
-        };
-        storeModules[storeName].actions.__setState = function __setState({ commit }, payload) {
+        storeModules[storeName].actions.__clearStorage =
+            function __clearStorage({ commit }) {
+                commit('__CLEAR_STORAGE');
+            };
+        storeModules[storeName].actions.__setState = function __setState(
+            { commit },
+            payload,
+        ) {
             commit('__SET_STATE', payload);
         };
 
         if (!moduleIsRegistered) {
-            app.store.registerModule(
-                storeName,
-                storeModules[storeName],
-                { preserveState: stateExists },
-            );
+            app.store.registerModule(storeName, storeModules[storeName], {
+                preserveState: stateExists,
+            });
         }
     });
 };

--- a/src/templates/routerHelper.ejs
+++ b/src/templates/routerHelper.ejs
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /*
  * Copyright © Bold Brand Commerce Sp. z o.o. All rights reserved.
  * See LICENSE for license details.
@@ -5,6 +6,33 @@
 
 import extendsModules from '~/.nuxt/extends.modules';
 import routerModules from '~/.nuxt/router.modules';
+
+function findExtendByName(name) {
+    return Object.values(extendsModules).reduce((acc, current) => {
+        let tmpArray = acc;
+
+        if (current[name]) {
+            tmpArray = [...acc, ...current[name]];
+        }
+        return tmpArray;
+    }, []);
+}
+
+export function replaceRoutes() {
+    const replaceRouteByName = findExtendByName('replaceRoutes');
+    const extendedRoutes = [].concat(...Object.values(routerModules));
+
+    for (let i = 0; i < replaceRouteByName.length; i += 1) {
+        const { name, routes } = replaceRouteByName[i];
+        const index = extendedRoutes.findIndex((e) => e.name === name);
+
+        if (index !== -1) {
+            extendedRoutes[index] = routes;
+        }
+    }
+
+    return extendedRoutes;
+}
 
 function middlewarePipeline({ context, middleware, index }) {
     const nextMiddleware = middleware[index];
@@ -15,7 +43,9 @@ function middlewarePipeline({ context, middleware, index }) {
 
     return () => {
         const nextPipeline = middlewarePipeline({
-            context, middleware, index: index + 1,
+            context,
+            middleware,
+            index: index + 1,
         });
 
         nextMiddleware({
@@ -25,15 +55,11 @@ function middlewarePipeline({ context, middleware, index }) {
     };
 }
 
-export function setLocalMiddlewares({
-    to, from, next, ...context
-}) {
+export function setLocalMiddlewares({ to, from, next, ...context }) {
     if (!to.meta.middleware) {
         return next();
     }
-    const {
-        middleware,
-    } = to.meta;
+    const { middleware } = to.meta;
     const ctx = {
         to,
         from,
@@ -48,34 +74,23 @@ export function setLocalMiddlewares({
 }
 
 export function extendRoutes(routerLocal = []) {
-    const extendRoutesChildren = Object.values(extendsModules)
-        .reduce((acc, current) => {
-            let connectedArray = acc;
-
-            if (current.extendRoutesChildren) {
-                connectedArray = [
-                    ...acc,
-                    ...current.extendRoutesChildren,
-                ];
-            }
-            return connectedArray;
-        }, []);
-    const extendedRoutes = [].concat(...Object.values(routerModules), routerLocal);
+    const extendRoutesChildren = findExtendByName('extendRoutesChildren');
+    const extendedRoutes = [].concat(
+        ...Object.values(replaceRoutes()),
+        routerLocal,
+    );
 
     for (let i = 0; i < extendRoutesChildren.length; i += 1) {
-        const index = extendedRoutes.findIndex(e => e.name === extendRoutesChildren[i].name);
+        const index = extendedRoutes.findIndex(
+            (e) => e.name === extendRoutesChildren[i].name,
+        );
 
         if (index !== -1) {
-            const {
-                children = [],
-            } = extendedRoutes[index];
+            const { children = [] } = extendedRoutes[index];
 
             extendedRoutes[index] = {
                 ...extendedRoutes[index],
-                children: [
-                    ...children,
-                    ...extendRoutesChildren[i].children,
-                ],
+                children: [...children, ...extendRoutesChildren[i].children],
             };
         }
     }
@@ -91,7 +106,9 @@ export function scrollBehavior(to, from, savedPosition) {
             x: 0,
             y: 0,
         };
-    } else if (to.matched.some(r => r.components.default.options.scrollToTop)) {
+    } else if (
+        to.matched.some((r) => r.components.default.options.scrollToTop)
+    ) {
         position = {
             x: 0,
             y: 0,


### PR DESCRIPTION
New property on `extends.js` file :  **replaceRoutes**

This functionality allows you to replace a routing page by his name.
The mechanism is based on routing and extends existing routing.

**`replaceRoutes`:**
    - `name` - existing router name what we want replace,
    - `routes` - new routing to replace,